### PR TITLE
fix: facets 수집 full/light 모드 및 중복 방지

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -64,6 +64,7 @@ program
   .option('-d, --date <YYYY-MM-DD>', 'Specific date to collect')
   .option('-a, --all', 'Collect all available historical data')
   .option('-o, --output <path>', 'Output path for collected data')
+  .option('--mode <full|light>', 'Collection mode (default: full)', 'full')
   .action(async (options) => {
     const spinner = ora('Collecting insights data...').start();
 
@@ -72,6 +73,7 @@ program
         date: options.date,
         collectAll: options.all,
         outputPath: options.output,
+        mode: options.mode,
       });
 
       spinner.succeed(chalk.green('Insights data collected successfully'));
@@ -822,8 +824,9 @@ program
       }
 
       console.log(chalk.blue('\nNext steps:'));
+      console.log('  • Hook path (default): auto full collection runs after each Claude session');
       console.log('  • Run: cit collect --all  (gather historical data)');
-      console.log('  • Run: cit daemon start   (start auto-collection)');
+      console.log('  • Run: cit daemon start   (optional realtime monitoring, light mode)');
     } catch (error) {
       spinner.fail(chalk.red('Setup failed'));
       if (error instanceof Error) {

--- a/src/collectors/__tests__/facets.test.ts
+++ b/src/collectors/__tests__/facets.test.ts
@@ -1,0 +1,176 @@
+import * as path from 'path';
+import { homedir } from 'os';
+import { collectFacets } from '../facets';
+
+jest.mock('fs/promises', () => ({
+  mkdir: jest.fn(),
+  readdir: jest.fn(),
+  stat: jest.fn(),
+  readFile: jest.fn(),
+  writeFile: jest.fn(),
+  open: jest.fn(),
+  unlink: jest.fn(),
+  access: jest.fn(),
+  copyFile: jest.fn(),
+}));
+
+jest.mock('../snapshot', () => ({
+  createSnapshot: jest.fn(),
+}));
+
+const fs = require('fs/promises');
+const { createSnapshot } = require('../snapshot');
+
+function createErrno(code: string): NodeJS.ErrnoException {
+  const err = new Error(code) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+describe('collectFacets', () => {
+  const home = homedir();
+  const facetsPath = path.join(home, '.claude', 'usage-data', 'facets');
+  const statePath = path.join(home, 'claude-insights', '.locks', 'collect-facets.state.json');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    fs.open.mockResolvedValue({ close: jest.fn().mockResolvedValue(undefined) });
+    fs.unlink.mockResolvedValue(undefined);
+    fs.mkdir.mockResolvedValue(undefined);
+    fs.writeFile.mockResolvedValue(undefined);
+    fs.access.mockResolvedValue(undefined);
+    fs.copyFile.mockResolvedValue(undefined);
+    createSnapshot.mockResolvedValue({
+      path: '/tmp/snapshot.json',
+      snapshot: { metrics: { costKpi: undefined } },
+    });
+  });
+
+  it('light mode skips report copy and snapshot generation', async () => {
+    fs.readdir.mockImplementation(async (target: string) => {
+      if (target === facetsPath) {
+        return ['session-b.json', 'session-a.json'];
+      }
+      return [];
+    });
+
+    fs.stat.mockResolvedValue({ mtime: new Date('2026-02-12T01:00:00.000Z') });
+
+    fs.readFile.mockImplementation(async (target: string) => {
+      if (target === statePath) {
+        throw createErrno('ENOENT');
+      }
+
+      if (target.endsWith('session-a.json')) {
+        return JSON.stringify({ session_id: 'a', underlying_goal: '', goal_categories: {}, outcome: 'fully_achieved', user_satisfaction_counts: {}, claude_helpfulness: 'very_helpful', session_type: 'single_task', friction_counts: {}, friction_detail: '', primary_success: 'correct_code_edits', brief_summary: '' });
+      }
+
+      if (target.endsWith('session-b.json')) {
+        return JSON.stringify({ session_id: 'b', underlying_goal: '', goal_categories: {}, outcome: 'fully_achieved', user_satisfaction_counts: {}, claude_helpfulness: 'very_helpful', session_type: 'single_task', friction_counts: {}, friction_detail: '', primary_success: 'correct_code_edits', brief_summary: '' });
+      }
+
+      throw createErrno('ENOENT');
+    });
+
+    const result = await collectFacets({
+      mode: 'light',
+      date: '2026-02-12',
+      outputPath: '/tmp/cit-data',
+    });
+
+    expect(result.reportCopied).toBe(false);
+    expect(result.snapshotCreated).toBe(false);
+    expect(fs.copyFile).not.toHaveBeenCalled();
+    expect(createSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('light mode skips during debounce window', async () => {
+    const now = 1700000000000;
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(now);
+
+    fs.readFile.mockImplementation(async (target: string) => {
+      if (target === statePath) {
+        return JSON.stringify({ lastLightRunAt: now - 1000 });
+      }
+      throw createErrno('ENOENT');
+    });
+
+    const result = await collectFacets({ mode: 'light', debounceMs: 5000 });
+
+    expect(result.skipped).toBe(true);
+    expect(result.skipReason).toContain('debounce');
+    expect(fs.readdir).not.toHaveBeenCalled();
+    expect(fs.copyFile).not.toHaveBeenCalled();
+
+    nowSpy.mockRestore();
+  });
+
+  it('full mode skips when fingerprint is unchanged', async () => {
+    fs.readFile.mockImplementation(async (target: string) => {
+      if (target === statePath) {
+        return JSON.stringify({ lastFullFingerprint: 'facets:0:0|report:none' });
+      }
+      throw createErrno('ENOENT');
+    });
+
+    fs.readdir.mockResolvedValue([]);
+    fs.stat.mockImplementation(async (target: string) => {
+      if (String(target).endsWith('report.html')) {
+        throw createErrno('ENOENT');
+      }
+      throw createErrno('ENOENT');
+    });
+
+    const result = await collectFacets({ mode: 'full' });
+
+    expect(result.skipped).toBe(true);
+    expect(result.skipReason).toContain('no changes detected');
+    expect(fs.copyFile).not.toHaveBeenCalled();
+    expect(createSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('writes deterministic session order regardless of input file order', async () => {
+    let currentOrder = ['session-b.json', 'session-a.json'];
+
+    fs.readdir.mockImplementation(async (target: string) => {
+      if (target === facetsPath) {
+        return currentOrder;
+      }
+      return [];
+    });
+
+    fs.stat.mockResolvedValue({ mtime: new Date('2026-02-12T01:00:00.000Z') });
+
+    fs.readFile.mockImplementation(async (target: string) => {
+      if (target === statePath) {
+        throw createErrno('ENOENT');
+      }
+
+      if (target.endsWith('session-a.json')) {
+        return JSON.stringify({ session_id: 'a', underlying_goal: '', goal_categories: {}, outcome: 'fully_achieved', user_satisfaction_counts: {}, claude_helpfulness: 'very_helpful', session_type: 'single_task', friction_counts: {}, friction_detail: '', primary_success: 'correct_code_edits', brief_summary: '' });
+      }
+
+      if (target.endsWith('session-b.json')) {
+        return JSON.stringify({ session_id: 'b', underlying_goal: '', goal_categories: {}, outcome: 'fully_achieved', user_satisfaction_counts: {}, claude_helpfulness: 'very_helpful', session_type: 'single_task', friction_counts: {}, friction_detail: '', primary_success: 'correct_code_edits', brief_summary: '' });
+      }
+
+      throw createErrno('ENOENT');
+    });
+
+    await collectFacets({ mode: 'light', collectAll: true, outputPath: '/tmp/cit-data-deterministic' });
+
+    const firstWrite = fs.writeFile.mock.calls.find((c: unknown[]) => String(c[0]).includes('/tmp/cit-data-deterministic/') && String(c[0]).endsWith('.json'));
+    const firstPayload = JSON.parse(firstWrite[1]);
+    expect(firstPayload.sessions.map((s: { session_id: string }) => s.session_id)).toEqual(['a', 'b']);
+
+    fs.writeFile.mockClear();
+    currentOrder = ['session-a.json', 'session-b.json'];
+
+    await collectFacets({ mode: 'light', collectAll: true, outputPath: '/tmp/cit-data-deterministic' });
+
+    const secondWrite = fs.writeFile.mock.calls.find((c: unknown[]) => String(c[0]).includes('/tmp/cit-data-deterministic/') && String(c[0]).endsWith('.json'));
+    const secondPayload = JSON.parse(secondWrite[1]);
+    expect(secondPayload.sessions.map((s: { session_id: string }) => s.session_id)).toEqual(['a', 'b']);
+  });
+});

--- a/src/collectors/facets.ts
+++ b/src/collectors/facets.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import { homedir } from 'os';
 import { IInsightsDay, ISessionFacet, ICostKpi } from '../types/insights';
 import { deduplicateDaySessions } from '../utils/sessions';
+import { createSnapshot } from './snapshot';
 
 const FACETS_PATH = path.join(homedir(), '.claude', 'usage-data', 'facets');
 const REPORT_PATH = path.join(homedir(), '.claude', 'usage-data', 'report.html');
@@ -14,11 +15,15 @@ const DEFAULT_OUTPUT_PATH = path.join(homedir(), 'claude-insights', 'data');
 const REPORTS_OUTPUT_PATH = path.join(homedir(), 'claude-insights', 'reports');
 const LOCK_DIR = path.join(homedir(), 'claude-insights', '.locks');
 const FACETS_COLLECT_LOCK = path.join(LOCK_DIR, 'collect-facets.lock');
+const FACETS_COLLECT_STATE_PATH = path.join(LOCK_DIR, 'collect-facets.state.json');
+const DEFAULT_LIGHT_DEBOUNCE_MS = 5000;
 
 export interface ICollectOptions {
   date?: string; // YYYY-MM-DD format, defaults to today
   collectAll?: boolean; // Collect all available dates
   outputPath?: string; // Where to save, defaults to ~/claude-insights/data/
+  mode?: 'full' | 'light'; // defaults to full
+  debounceMs?: number; // light mode only
 }
 
 export interface ICollectResult {
@@ -41,6 +46,71 @@ function getToday(): string {
   return new Date().toISOString().split('T')[0];
 }
 
+type CollectMode = 'full' | 'light';
+
+interface ICollectFacetsState {
+  lastLightRunAt?: number;
+  lastFullFingerprint?: string;
+}
+
+async function readCollectorState(): Promise<ICollectFacetsState> {
+  try {
+    const raw = await fs.readFile(FACETS_COLLECT_STATE_PATH, 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<ICollectFacetsState>;
+    return {
+      lastLightRunAt: typeof parsed.lastLightRunAt === 'number' ? parsed.lastLightRunAt : undefined,
+      lastFullFingerprint: typeof parsed.lastFullFingerprint === 'string' ? parsed.lastFullFingerprint : undefined,
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return {};
+    }
+    return {};
+  }
+}
+
+async function writeCollectorState(state: ICollectFacetsState): Promise<void> {
+  await fs.mkdir(LOCK_DIR, { recursive: true });
+  await fs.writeFile(FACETS_COLLECT_STATE_PATH, JSON.stringify(state, null, 2), 'utf-8');
+}
+
+async function buildFacetsFingerprint(mode: CollectMode): Promise<string> {
+  let count = 0;
+  let latestMtimeMs = 0;
+
+  try {
+    const files = await fs.readdir(FACETS_PATH);
+    const jsonFiles = files.filter((f) => f.endsWith('.json'));
+    count = jsonFiles.length;
+
+    for (const file of jsonFiles) {
+      const stat = await fs.stat(path.join(FACETS_PATH, file));
+      latestMtimeMs = Math.max(latestMtimeMs, stat.mtime.getTime());
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  let fingerprint = `facets:${count}:${latestMtimeMs}`;
+
+  if (mode === 'full') {
+    try {
+      const reportStat = await fs.stat(REPORT_PATH);
+      fingerprint += `|report:${reportStat.mtime.getTime()}:${reportStat.size}`;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        fingerprint += '|report:none';
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  return fingerprint;
+}
+
 /**
  * Read all facet files from the source directory
  */
@@ -49,7 +119,7 @@ async function readFacetFiles(): Promise<Map<string, ISessionFacet[]>> {
 
   try {
     const files = await fs.readdir(FACETS_PATH);
-    const jsonFiles = files.filter(f => f.endsWith('.json'));
+    const jsonFiles = files.filter((f) => f.endsWith('.json')).sort();
 
     for (const file of jsonFiles) {
       const filePath = path.join(FACETS_PATH, file);
@@ -141,6 +211,7 @@ async function releaseCollectLock(): Promise<void> {
 export async function collectFacets(options: ICollectOptions = {}): Promise<ICollectResult> {
   const outputPath = options.outputPath || DEFAULT_OUTPUT_PATH;
   const targetDate = options.date || getToday();
+  const mode: CollectMode = options.mode || 'full';
 
   const lockAcquired = await acquireCollectLock();
   if (!lockAcquired) {
@@ -156,6 +227,40 @@ export async function collectFacets(options: ICollectOptions = {}): Promise<ICol
   }
 
   try {
+    const state = await readCollectorState();
+    const now = Date.now();
+
+    if (mode === 'light') {
+      const debounceMs = options.debounceMs ?? DEFAULT_LIGHT_DEBOUNCE_MS;
+      if (state.lastLightRunAt && now - state.lastLightRunAt < debounceMs) {
+        return {
+          sessionsCollected: 0,
+          datesProcessed: [],
+          storagePath: outputPath,
+          reportCopied: false,
+          snapshotCreated: false,
+          skipped: true,
+          skipReason: `Collection skipped: light mode debounce (${debounceMs}ms)`,
+        };
+      }
+    }
+
+    let fullFingerprint: string | undefined;
+    if (mode === 'full') {
+      fullFingerprint = await buildFacetsFingerprint('full');
+      if (state.lastFullFingerprint && fullFingerprint === state.lastFullFingerprint) {
+        return {
+          sessionsCollected: 0,
+          datesProcessed: [],
+          storagePath: outputPath,
+          reportCopied: false,
+          snapshotCreated: false,
+          skipped: true,
+          skipReason: 'Collection skipped: no changes detected since last full run',
+        };
+      }
+    }
+
     const dateMap = await readFacetFiles();
     const datesProcessed: string[] = [];
     let totalSessions = 0;
@@ -164,22 +269,39 @@ export async function collectFacets(options: ICollectOptions = {}): Promise<ICol
       // Process all available dates
       for (const [date, sessions] of Array.from(dateMap.entries())) {
         const dedupedDay = deduplicateDaySessions({ date, sessions });
-        await saveDailyData(date, dedupedDay.sessions, outputPath);
+        const sortedSessions = [...dedupedDay.sessions].sort((a, b) => a.session_id.localeCompare(b.session_id));
+        await saveDailyData(date, sortedSessions, outputPath);
         datesProcessed.push(date);
-        totalSessions += dedupedDay.sessions.length;
+        totalSessions += sortedSessions.length;
       }
     } else {
       // Process only the target date
       const sessions = dateMap.get(targetDate) || [];
       if (sessions.length > 0) {
         const dedupedDay = deduplicateDaySessions({ date: targetDate, sessions });
-        await saveDailyData(targetDate, dedupedDay.sessions, outputPath);
+        const sortedSessions = [...dedupedDay.sessions].sort((a, b) => a.session_id.localeCompare(b.session_id));
+        await saveDailyData(targetDate, sortedSessions, outputPath);
         datesProcessed.push(targetDate);
-        totalSessions = dedupedDay.sessions.length;
+        totalSessions = sortedSessions.length;
       }
     }
 
-    // Copy report.html if available
+    if (mode === 'light') {
+      await writeCollectorState({
+        ...state,
+        lastLightRunAt: now,
+      });
+
+      return {
+        sessionsCollected: totalSessions,
+        datesProcessed,
+        storagePath: outputPath,
+        reportCopied: false,
+        snapshotCreated: false,
+      };
+    }
+
+    // full mode: copy report.html if available
     const reportResult = await copyReportHtml(targetDate);
 
     // Create snapshot from report if available
@@ -189,7 +311,6 @@ export async function collectFacets(options: ICollectOptions = {}): Promise<ICol
 
     if (reportResult.copied && reportResult.path) {
       try {
-        const { createSnapshot } = await import('./snapshot');
         const snapshotResult = await createSnapshot(
           reportResult.path,
           totalSessions,
@@ -202,6 +323,11 @@ export async function collectFacets(options: ICollectOptions = {}): Promise<ICol
         console.warn('Warning: Failed to create snapshot:', error instanceof Error ? error.message : error);
       }
     }
+
+    await writeCollectorState({
+      ...state,
+      lastFullFingerprint: fullFingerprint,
+    });
 
     return {
       sessionsCollected: totalSessions,

--- a/src/commands/__tests__/health.test.ts
+++ b/src/commands/__tests__/health.test.ts
@@ -35,6 +35,7 @@ describe('runHealthCheck', () => {
   const todaySnapshotArtifact = path.join(outputSnapshots, `snapshot-${today}.json`);
   const hookScript = path.join(home, '.claude', 'hooks', 'cit-auto-collect.js');
   const settingsFile = path.join(home, '.claude', 'settings.json');
+  const daemonPidFile = path.join(home, 'claude-insights', '.daemon.pid');
 
   beforeEach(() => {
     jest.useFakeTimers();
@@ -111,5 +112,29 @@ describe('runHealthCheck', () => {
     const artifactChecks = result.checks.filter((c) => c.name.includes("today's"));
     expect(artifactChecks).toHaveLength(3);
     expect(artifactChecks.every((c) => c.status === 'WARN')).toBe(true);
+  });
+
+  it('returns WARN for duplicate trigger risk when hook is active and daemon pid exists', async () => {
+    createAccessMock(
+      new Set([
+        sourceFacets,
+        sourceReport,
+        outputDir,
+        outputData,
+        outputReports,
+        todayDataArtifact,
+        todayReportArtifact,
+        todaySnapshotArtifact,
+        hookScript,
+        settingsFile,
+        daemonPidFile,
+      ]),
+    );
+
+    const result = await runHealthCheck();
+
+    const duplicateCheck = result.checks.find((c) => c.name === 'hook + daemon duplicate trigger risk');
+    expect(duplicateCheck?.status).toBe('WARN');
+    expect(result.status).toBe('WARN');
   });
 });

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -25,6 +25,7 @@ const OUTPUT_SNAPSHOTS_DIR = path.join(OUTPUT_DIR, 'snapshots');
 const HOOK_SCRIPT = path.join(HOME, '.claude', 'hooks', 'cit-auto-collect.js');
 const LEGACY_HOOK_SCRIPT = path.join(HOME, '.claude', 'hooks', 'insights-auto-collect.sh');
 const SETTINGS_FILE = path.join(HOME, '.claude', 'settings.json');
+const DAEMON_PID_FILE = path.join(HOME, 'claude-insights', '.daemon.pid');
 
 async function exists(target: string): Promise<boolean> {
   try {
@@ -138,6 +139,15 @@ export async function runHealthCheck(): Promise<IHealthCheckResult> {
     details: (await exists(LEGACY_HOOK_SCRIPT))
       ? `Legacy hook found: ${LEGACY_HOOK_SCRIPT}`
       : 'No legacy hook detected',
+  });
+
+  const daemonPidExists = await exists(DAEMON_PID_FILE);
+  checks.push({
+    name: 'hook + daemon duplicate trigger risk',
+    status: hookExists && hookRegistered && daemonPidExists ? 'WARN' : 'PASS',
+    details: hookExists && hookRegistered && daemonPidExists
+      ? `Hook is active and daemon PID found (${DAEMON_PID_FILE}); duplicate collection can occur`
+      : 'No hook/daemon duplicate trigger risk detected',
   });
 
   let recencyCheck: IHealthCheckItem = {

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -166,6 +166,8 @@ export async function runSetup(): Promise<ISetupResult> {
     steps.push(`Validation passed: ${validations.join(', ')}`);
   }
 
+  steps.push('Collection roles: post-session hook is default full collection path; daemon is optional realtime monitoring only');
+
   return {
     success: errors.length === 0,
     steps,

--- a/src/services/daemon.ts
+++ b/src/services/daemon.ts
@@ -62,8 +62,12 @@ export async function startDaemon(): Promise<void> {
 
     try {
       const { collectFacets } = await import('../collectors/facets');
-      const result = await collectFacets();
-      logMessage(`Collection complete: ${result.sessionsCollected} sessions from ${result.datesProcessed.join(', ')}`);
+      const result = await collectFacets({ mode: 'light' });
+      if (result.skipped) {
+        logMessage(`Collection skipped: ${result.skipReason || 'no reason provided'}`);
+      } else {
+        logMessage(`Collection complete: ${result.sessionsCollected} sessions from ${result.datesProcessed.join(', ')}`);
+      }
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       logMessage(`Collection failed: ${msg}`);


### PR DESCRIPTION
## Summary
- `collectFacets`에 수집 모드(`full|light`)를 도입하고 debounce/idempotency로 연속 중복 실행을 억제했습니다.
- daemon watcher는 `light` 모드만 호출하도록 변경했습니다.
- `cit collect`에 `--mode <full|light>` 옵션을 추가했습니다.
- `cit health`에 hook + daemon 동시 활성 시 WARN을 추가했습니다.

## Test plan
- [x] npm run build
- [x] npm test -- src/commands/__tests__/health.test.ts
- [x] npm test -- src/collectors/__tests__/facets.test.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)