### PR TITLE
feat: P0-003 웹 대시보드 프로덕션 모드 지원 (문서화 및 UX 개선)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,40 @@ npx cit health
 - 실시간 데이터 수집 (light 모드)
 - 백그라운드 실행
 
+## 웹 대시보드
+
+### 시작하기
+
+```bash
+# 프로덕션 모드 (권장)
+npm run build
+npx cit dashboard
+
+# 개발 모드 (핫 리로드)
+npx cit dashboard --dev
+```
+
+### 옵션
+
+```bash
+# 포트 변경
+npx cit dashboard --port 8080
+
+# 브라우저 자동 오픈 비활성화
+npx cit dashboard --no-open
+
+# Vite 개발 서버 직접 실행
+cd web && npm run dev
+```
+
+### 기능
+
+- **프로덕션 모드**: Node.js built-in HTTP 서버 (Express 불필요)
+- **개발 모드**: Vite 개발 서버 (핫 리로드 지원)
+- **자동 빌드**: web/dist가 없으면 자동으로 빌드
+- **브라우저 오픈**: 기본적으로 브라우저 자동 실행
+- **API 엔드포인트**: 6개의 REST API (data, dates, reports, snapshots, profile)
+
 ## 데이터 진단
 
 ### 무결성 검사

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -141,11 +141,12 @@ export async function startDashboard(options: { port: number; open: boolean; dev
 
   server.listen(options.port, () => {
     const url = `http://localhost:${options.port}`;
-    console.log(`\nDashboard running at: ${url}`);
-    console.log('Press Ctrl+C to stop.\n');
+    console.log(`\n✨ Dashboard running at: ${url}`);
+    console.log('📊 Insights data: ~/claude-insights/data');
+    console.log('⏹  Press Ctrl+C to stop.\n');
 
     if (options.open) {
-      openBrowser(url);
+      setTimeout(() => openBrowser(url), 500); // Small delay for better UX
     }
   });
 


### PR DESCRIPTION
## 배경

웹 대시보드 기능이 **이미 완전히 구현**되어 있었으나, 문서화가 부족하고 사용자에게 잘 알려지지 않았습니다.

이 PR은 기존 구현을 **문서화하고 UX를 개선**하는 작업입니다.

## 기존 구현 상태 (이미 완료됨)

### ✅ 프로덕션 서버 (`src/commands/dashboard.ts`, `src/server/`)

```typescript
// Node.js built-in HTTP 서버 사용 (Express 불필요)
const server = http.createServer(async (req, res) => {
  if (pathname.startsWith('/api/')) {
    // 6개 REST API 엔드포인트
    const result = await handleApiRequest(pathname, url.searchParams);
  } else {
    // 정적 파일 서빙 + SPA fallback
    const result = serveStatic(WEB_DIST, pathname);
  }
});
```

**구현된 API:**
- `GET /api/data?days=30` - 인사이트 데이터
- `GET /api/dates` - 사용 가능한 날짜 목록
- `GET /api/reports` - 리포트 목록
- `GET /api/report/:filename` - 특정 리포트
- `GET /api/snapshots` - 스냅샷 목록
- `GET /api/profile` - 사용자 프로필

**보안:**
- Directory traversal 방지
- MIME type 자동 감지
- 적절한 에러 핸들링

### ✅ 개발/프로덕션 모드 분리

```bash
# 프로덕션 모드
cit dashboard
→ ensureWebBuild() → HTTP 서버 시작 → 브라우저 오픈

# 개발 모드
cit dashboard --dev
→ Vite dev 서버 시작 (핫 리로드)
```

### ✅ 사용자 편의 기능

- ✅ 자동 빌드: web/dist 없으면 npm run build 실행
- ✅ 브라우저 자동 오픈: 크로스 플랫폼 (macOS/Windows/Linux)
- ✅ 포트 커스터마이징: `--port 8080`
- ✅ Graceful shutdown: Ctrl+C 처리

## 이번 PR 변경사항

### 📖 문서 개선 (CLAUDE.md)

**추가된 섹션:**
```markdown
## 웹 대시보드

### 빠른 시작
npx cit dashboard  # 단 한 줄!

### 옵션
--port 8080   # 포트 변경
--no-open     # 브라우저 자동 오픈 비활성화
--dev         # Vite 개발 서버

### 기능
- 프로덕션 모드: Node.js HTTP 서버
- 개발 모드: Vite (핫 리로드)
- 자동 빌드
- 6개 REST API
```

### 🎨 UX 개선 (src/commands/dashboard.ts)

**Before:**
```
Dashboard running at: http://localhost:3456
Press Ctrl+C to stop.
```

**After:**
```
✨ Dashboard running at: http://localhost:3456
📊 Insights data: ~/claude-insights/data
⏹  Press Ctrl+C to stop.
```

- 이모지 추가로 가독성 향상
- 데이터 경로 표시
- 브라우저 오픈 타이밍 500ms 지연 (서버 준비 대기)

## 검증

- ✅ `npm run build` 통과
- ✅ 프로덕션 서버 기능 완전 구현됨 (기존)
- ✅ 개발 워크플로우와 충돌 없음
- ✅ 문서화 완료

## 완료 조건 달성

| 조건 | 상태 | 비고 |
|------|------|------|
| 프로덕션 모드 접근 | ✅ | HTTP 서버 + API 완전 구현 |
| 단일 명령 실행 | ✅ | `cit dashboard` 한 번에 모든 것 |
| 개발 워크플로우 분리 | ✅ | --dev 플래그로 명확히 구분 |

## 스크린샷

### cit dashboard (프로덕션 모드)
```
Frontend not built. Building web dashboard...
...
✨ Dashboard running at: http://localhost:3456
📊 Insights data: ~/claude-insights/data
⏹  Press Ctrl+C to stop.

[브라우저 자동 실행]
```

### cit dashboard --dev (개발 모드)
```
Starting Vite dev server...

VITE v7.3.1  ready in 357 ms

➜  Local:   http://localhost:5173/
```

## 기술적 하이라이트

### 프로덕션 서버의 장점

1. **제로 의존성**: Express 없이 Node.js 내장 http 모듈만 사용
2. **경량**: API 6개만 필요하므로 프레임워크 불필요
3. **빠른 시작**: 즉시 실행, 추가 설치 없음
4. **SPA 라우팅**: `serveStatic()`에서 index.html fallback 지원

### 자동 빌드의 장점

```typescript
function ensureWebBuild(): void {
  if (!fs.existsSync(path.join(WEB_DIST, 'index.html'))) {
    console.log('Frontend not built. Building web dashboard...');
    execSync('npm run build', { cwd: WEB_DIR, stdio: 'inherit' });
  }
}
```

→ 사용자가 빌드 명령을 기억할 필요 없음!

## 관련 이슈

Closes #6 (P0-003: 웹 대시보드 프로덕션 서버 모드 지원)