### PR TITLE
feat: P1-001 웹 대시보드 5대 분석 Recharts 시각화

### DIFF
--- a/web/src/pages/ApiErrorsPage.tsx
+++ b/web/src/pages/ApiErrorsPage.tsx
@@ -6,6 +6,7 @@ import { LoadingState, ErrorState, EmptyState } from '@/components/LoadingState'
 import { MetricCard } from '@/components/MetricCard'
 import { analyzeApiErrors } from '@/lib/analyzers'
 import type { IApiErrorResult, IApiErrorSession, IApiErrorTrend } from '@shared/analyzers/api-errors'
+import { LineChart, Line, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts'
 
 export function ApiErrorsPage() {
   const { t } = useTranslation()
@@ -74,31 +75,44 @@ export function ApiErrorsPage() {
       )}
 
       {/* Error Types Breakdown */}
-      <div className="bg-slate-800 rounded-xl border border-slate-700 p-6">
-        <h3 className="text-lg font-semibold text-white mb-4">Error Types</h3>
-        {result.errorTypes.length > 0 ? (
-          <div className="space-y-3">
-            {result.errorTypes.map((errorType) => (
-              <div key={errorType.type} className="flex items-center justify-between">
-                <div className="flex-1">
-                  <div className="flex items-center justify-between mb-1">
-                    <span className="text-slate-300 text-sm">{errorType.type}</span>
-                    <span className="text-slate-400 text-xs">{errorType.count} errors in {errorType.sessions} sessions</span>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Bar Chart */}
+        <div className="bg-slate-800 rounded-xl border border-slate-700 p-6">
+          <h3 className="text-lg font-semibold text-white mb-4">Error Types Distribution</h3>
+          {result.errorTypes.length > 0 ? (
+            <div className="space-y-3">
+              {result.errorTypes.map((errorType) => (
+                <div key={errorType.type} className="flex items-center justify-between">
+                  <div className="flex-1">
+                    <div className="flex items-center justify-between mb-1">
+                      <span className="text-slate-300 text-sm">{errorType.type}</span>
+                      <span className="text-slate-400 text-xs">{errorType.count} errors in {errorType.sessions} sessions</span>
+                    </div>
+                    <div className="h-2 bg-slate-700 rounded-full overflow-hidden">
+                      <div
+                        className="h-full bg-rose-500 rounded-full"
+                        style={{ width: `${Math.min(100, (errorType.count / (result.errorTypes[0]?.count || 1)) * 100)}%` }}
+                      />
+                    </div>
                   </div>
-                  <div className="h-2 bg-slate-700 rounded-full overflow-hidden">
-                    <div
-                      className="h-full bg-rose-500 rounded-full"
-                      style={{ width: `${Math.min(100, (errorType.count / (result.errorTypes[0]?.count || 1)) * 100)}%` }}
-                    />
-                  </div>
+                  <span className="ml-4 text-slate-400 text-xs w-16 text-right">{errorType.percentageOfErrorSessions}%</span>
                 </div>
-                <span className="ml-4 text-slate-400 text-xs w-16 text-right">{errorType.percentageOfErrorSessions}%</span>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <p className="text-slate-400 text-sm">No API errors detected 🎉</p>
-        )}
+              ))}
+            </div>
+          ) : (
+            <p className="text-slate-400 text-sm">No API errors detected 🎉</p>
+          )}
+        </div>
+
+        {/* Pie Chart */}
+        <div className="bg-slate-800 rounded-xl border border-slate-700 p-6">
+          <h3 className="text-lg font-semibold text-white mb-4">Error Type Proportion</h3>
+          {result.errorTypes.length > 0 ? (
+            <ErrorTypesPieChart errorTypes={result.errorTypes.slice(0, 8)} />
+          ) : (
+            <p className="text-slate-400 text-sm">No API errors detected 🎉</p>
+          )}
+        </div>
       </div>
 
       {/* Trend Chart */}
@@ -179,26 +193,29 @@ export function ApiErrorsPage() {
 }
 
 function TrendChart({ trends }: { trends: IApiErrorTrend[] }) {
-  const maxErrors = Math.max(...trends.map(t => t.totalErrorCount), 1)
+  const chartData = trends.map(t => ({
+    date: t.date.slice(5), // MM-DD format
+    errors: t.totalErrorCount,
+    sessions: t.errorSessions
+  }))
 
   return (
-    <div className="h-64 flex items-end gap-2">
-      {trends.map((trend) => {
-        const height = (trend.totalErrorCount / maxErrors) * 100
-        return (
-          <div key={trend.date} className="flex-1 flex flex-col items-center gap-1">
-            <div className="w-full flex flex-col items-center">
-              <span className="text-xs text-slate-400 mb-1">{trend.totalErrorCount}</span>
-              <div
-                className="w-full bg-rose-500/80 rounded-t"
-                style={{ height: `${Math.max(height, 4)}px` }}
-              />
-            </div>
-            <span className="text-xs text-slate-500">{trend.date.slice(5)}</span>
-          </div>
-        )
-      })}
-    </div>
+    <ResponsiveContainer width="100%" height={300}>
+      <LineChart data={chartData} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+        <XAxis dataKey="date" stroke="#94a3b8" fontSize={12} />
+        <YAxis yAxisId="left" stroke="#94a3b8" fontSize={12} />
+        <YAxis yAxisId="right" orientation="right" stroke="#94a3b8" fontSize={12} />
+        <Tooltip
+          contentStyle={{ backgroundColor: '#1e293b', border: '1px solid #334155', borderRadius: '8px' }}
+          labelStyle={{ color: '#cbd5e1' }}
+          itemStyle={{ color: '#e2e8f0' }}
+        />
+        <Legend wrapperStyle={{ color: '#94a3b8' }} />
+        <Line yAxisId="left" type="monotone" dataKey="errors" stroke="#f43f5e" strokeWidth={2} name="Total Errors" />
+        <Line yAxisId="right" type="monotone" dataKey="sessions" stroke="#f59e0b" strokeWidth={2} name="Error Sessions" />
+      </LineChart>
+    </ResponsiveContainer>
   )
 }
 
@@ -285,4 +302,40 @@ function getRecommendationBadgeStyles(type: string): string {
     default:
       return 'bg-blue-500 text-white'
   }
+}
+
+function ErrorTypesPieChart({ errorTypes }: { errorTypes: Array<{ type: string; count: number }> }) {
+  const COLORS = ['#f43f5e', '#f59e0b', '#3b82f6', '#8b5cf6', '#10b981', '#ec4899', '#14b8a6', '#f97316']
+
+  const data = errorTypes.map((et, idx) => ({
+    name: et.type.length > 20 ? et.type.slice(0, 20) + '...' : et.type,
+    value: et.count,
+    fullName: et.type
+  }))
+
+  return (
+    <ResponsiveContainer width="100%" height={280}>
+      <PieChart>
+        <Pie
+          data={data}
+          cx="50%"
+          cy="50%"
+          labelLine={false}
+          label={({ name, percent }) => `${name} ${percent ? (percent * 100).toFixed(0) : 0}%`}
+          outerRadius={90}
+          fill="#8884d8"
+          dataKey="value"
+        >
+          {data.map((entry, index) => (
+            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+          ))}
+        </Pie>
+        <Tooltip
+          contentStyle={{ backgroundColor: '#1e293b', border: '1px solid #334155', borderRadius: '8px' }}
+          labelStyle={{ color: '#cbd5e1' }}
+          itemStyle={{ color: '#e2e8f0' }}
+        />
+      </PieChart>
+    </ResponsiveContainer>
+  )
 }

--- a/web/src/pages/CategorySuccessPage.tsx
+++ b/web/src/pages/CategorySuccessPage.tsx
@@ -6,6 +6,7 @@ import { LoadingState, ErrorState, EmptyState } from '@/components/LoadingState'
 import { MetricCard } from '@/components/MetricCard'
 import { analyzeProductivity } from '@/lib/analyzers'
 import type { ICategoryStats } from '@shared/analyzers/productivity'
+import { RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Radar, Legend, ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Cell } from 'recharts'
 
 export function CategorySuccessPage() {
   const { t } = useTranslation()
@@ -64,9 +65,32 @@ export function CategorySuccessPage() {
         />
       </div>
 
-      {/* Category Success Bar Chart */}
+      {/* Category Success Visualization */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Bar Chart */}
+        <div className="bg-slate-800 rounded-xl border border-slate-700 p-6">
+          <h3 className="text-lg font-semibold text-white mb-4">Success Rate Comparison</h3>
+          {result.categoryStats.length > 0 ? (
+            <CategorySuccessBarChart categories={result.categoryStats.slice(0, 8)} />
+          ) : (
+            <p className="text-slate-400 text-sm">No category data available</p>
+          )}
+        </div>
+
+        {/* Radar Chart */}
+        <div className="bg-slate-800 rounded-xl border border-slate-700 p-6">
+          <h3 className="text-lg font-semibold text-white mb-4">Category Performance Radar</h3>
+          {result.categoryStats.length >= 3 ? (
+            <CategoryRadarChart categories={result.categoryStats.slice(0, 6)} />
+          ) : (
+            <p className="text-slate-400 text-sm">Need at least 3 categories for radar chart</p>
+          )}
+        </div>
+      </div>
+
+      {/* Detailed Category List */}
       <div className="bg-slate-800 rounded-xl border border-slate-700 p-6">
-        <h3 className="text-lg font-semibold text-white mb-4">Success Rate by Category</h3>
+        <h3 className="text-lg font-semibold text-white mb-4">Detailed Breakdown</h3>
         {result.categoryStats.length > 0 ? (
           <div className="space-y-3">
             {result.categoryStats.slice(0, 10).map((category) => (
@@ -202,5 +226,58 @@ function CategoryBar({ category }: { category: ICategoryStats }) {
         </div>
       </div>
     </div>
+  )
+}
+
+function CategorySuccessBarChart({ categories }: { categories: ICategoryStats[] }) {
+  const chartData = categories.map(c => ({
+    name: c.category.length > 15 ? c.category.slice(0, 15) + '...' : c.category.replace(/_/g, ' '),
+    rate: c.successRate,
+    sessions: c.sessions
+  }))
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={chartData} margin={{ top: 5, right: 10, left: 10, bottom: 60 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+        <XAxis dataKey="name" stroke="#94a3b8" fontSize={11} angle={-45} textAnchor="end" height={80} />
+        <YAxis stroke="#94a3b8" fontSize={12} domain={[0, 100]} />
+        <Tooltip
+          contentStyle={{ backgroundColor: '#1e293b', border: '1px solid #334155', borderRadius: '8px' }}
+          labelStyle={{ color: '#cbd5e1' }}
+          itemStyle={{ color: '#e2e8f0' }}
+        />
+        <Bar dataKey="rate" name="Success Rate (%)" radius={[4, 4, 0, 0]}>
+          {chartData.map((entry, index) => (
+            <Cell key={`cell-${index}`} fill={entry.rate >= 70 ? '#10b981' : entry.rate >= 50 ? '#f59e0b' : '#f43f5e'} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}
+
+function CategoryRadarChart({ categories }: { categories: ICategoryStats[] }) {
+  const chartData = categories.map(c => ({
+    category: c.category.length > 12 ? c.category.slice(0, 12) + '...' : c.category.replace(/_/g, ' '),
+    successRate: c.successRate,
+    sessions: Math.min(c.sessions * 10, 100) // Normalize sessions to 0-100
+  }))
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <RadarChart cx="50%" cy="50%" outerRadius="80%" data={chartData}>
+        <PolarGrid stroke="#334155" />
+        <PolarAngleAxis dataKey="category" stroke="#94a3b8" fontSize={11} />
+        <PolarRadiusAxis stroke="#94a3b8" fontSize={10} domain={[0, 100]} />
+        <Radar name="Success Rate" dataKey="successRate" stroke="#10b981" fill="#10b981" fillOpacity={0.6} />
+        <Legend wrapperStyle={{ color: '#94a3b8', fontSize: '12px' }} />
+        <Tooltip
+          contentStyle={{ backgroundColor: '#1e293b', border: '1px solid #334155', borderRadius: '8px' }}
+          labelStyle={{ color: '#cbd5e1' }}
+          itemStyle={{ color: '#e2e8f0' }}
+        />
+      </RadarChart>
+    </ResponsiveContainer>
   )
 }

--- a/web/src/pages/HelpfulnessPage.tsx
+++ b/web/src/pages/HelpfulnessPage.tsx
@@ -6,6 +6,7 @@ import { LoadingState, ErrorState, EmptyState } from '@/components/LoadingState'
 import { MetricCard } from '@/components/MetricCard'
 import { analyzeProductivity, getHelpfulnessScore, getSatisfactionRatio } from '@/lib/analyzers'
 import type { IHelpfulnessCorrelation } from '@shared/analyzers/productivity'
+import { ScatterChart, Scatter, XAxis, YAxis, ZAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, Cell } from 'recharts'
 
 export function HelpfulnessPage() {
   const { t } = useTranslation()
@@ -104,7 +105,8 @@ export function HelpfulnessPage() {
       {/* Helpfulness vs Outcome Correlation */}
       <div className="bg-slate-800 rounded-xl border border-slate-700 p-6">
         <h3 className="text-lg font-semibold text-white mb-4">Helpfulness vs Outcome Correlation</h3>
-        <div className="overflow-x-auto">
+        <HelpfulnessScatterChart correlations={result.helpfulnessCorrelation} />
+        <div className="overflow-x-auto mt-6">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-slate-700 text-slate-400">
@@ -377,4 +379,75 @@ function analyzeSatisfactionCorrelation(data: import('@/types').IInsightsDay[]):
     satisfactionByOutcome,
     insights,
   }
+}
+
+function HelpfulnessScatterChart({ correlations }: { correlations: IHelpfulnessCorrelation[] }) {
+  const helpfulnessScoreMap: Record<string, number> = {
+    'very_unhelpful': 0,
+    'unhelpful': 1,
+    'somewhat_helpful': 2,
+    'helpful': 3,
+    'very_helpful': 4
+  }
+
+  const chartData = correlations.map(c => ({
+    name: c.helpfulness.replace(/_/g, ' '),
+    x: helpfulnessScoreMap[c.helpfulness] || 0,
+    y: c.successRate,
+    z: c.total, // Size represents number of sessions
+    satisfaction: c.avgSatisfactionRatio
+  }))
+
+  const COLORS: Record<number, string> = {
+    0: '#f43f5e', // very unhelpful - rose
+    1: '#f59e0b', // unhelpful - amber
+    2: '#6366f1', // somewhat helpful - indigo
+    3: '#10b981', // helpful - emerald
+    4: '#059669'  // very helpful - dark emerald
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <ScatterChart margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+        <XAxis
+          type="number"
+          dataKey="x"
+          name="Helpfulness"
+          domain={[0, 4]}
+          ticks={[0, 1, 2, 3, 4]}
+          tickFormatter={(value) => ['Very\nUnhelpful', 'Unhelpful', 'Somewhat', 'Helpful', 'Very\nHelpful'][value] || ''}
+          stroke="#94a3b8"
+          fontSize={10}
+        />
+        <YAxis
+          type="number"
+          dataKey="y"
+          name="Success Rate"
+          unit="%"
+          stroke="#94a3b8"
+          fontSize={12}
+          domain={[0, 100]}
+        />
+        <ZAxis type="number" dataKey="z" range={[50, 400]} name="Sessions" />
+        <Tooltip
+          cursor={{ strokeDasharray: '3 3' }}
+          contentStyle={{ backgroundColor: '#1e293b', border: '1px solid #334155', borderRadius: '8px' }}
+          labelStyle={{ color: '#cbd5e1' }}
+          itemStyle={{ color: '#e2e8f0' }}
+          formatter={(value: any, name?: string) => {
+            if (name === 'Success Rate') return [`${value}%`, name]
+            if (name === 'Sessions') return [value, name || '']
+            return [value, name || '']
+          }}
+        />
+        <Legend wrapperStyle={{ color: '#94a3b8', fontSize: '12px' }} />
+        <Scatter name="Helpfulness → Success" data={chartData}>
+          {chartData.map((entry, index) => (
+            <Cell key={`cell-${index}`} fill={COLORS[entry.x] || '#6366f1'} />
+          ))}
+        </Scatter>
+      </ScatterChart>
+    </ResponsiveContainer>
+  )
 }

--- a/web/src/pages/SessionEfficiencyPage.tsx
+++ b/web/src/pages/SessionEfficiencyPage.tsx
@@ -5,6 +5,7 @@ import { PeriodSelector } from '@/components/PeriodSelector'
 import { LoadingState, ErrorState, EmptyState } from '@/components/LoadingState'
 import { MetricCard } from '@/components/MetricCard'
 import type { IInsightsDay, ISessionFacet } from '@/types'
+import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, BarChart, Bar, Cell } from 'recharts'
 
 interface IEfficiencyResult {
   summary: string
@@ -111,30 +112,7 @@ export function SessionEfficiencyPage() {
       {/* Iteration Distribution */}
       <div className="bg-slate-800 rounded-xl border border-slate-700 p-6">
         <h3 className="text-lg font-semibold text-white mb-4">Iteration Count Distribution</h3>
-        <div className="space-y-3">
-          {result.iterationDistribution.map((range) => (
-            <div key={range.range} className="flex items-center gap-4">
-              <div className="w-24 text-slate-300 text-sm">{range.range}</div>
-              <div className="flex-1">
-                <div className="flex items-center justify-between mb-1">
-                  <span className="text-slate-400 text-xs">{range.count} sessions</span>
-                  <span className="text-slate-400 text-xs">{range.percentage}%</span>
-                </div>
-                <div className="h-2 bg-slate-700 rounded-full overflow-hidden">
-                  <div
-                    className={`h-full rounded-full ${
-                      range.range.includes('10+') ? 'bg-rose-500' :
-                      range.range.includes('7-9') ? 'bg-amber-500' :
-                      range.range.includes('4-6') ? 'bg-indigo-500' :
-                      'bg-emerald-500'
-                    }`}
-                    style={{ width: `${Math.max(range.percentage, 4)}%` }}
-                  />
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
+        <IterationDistributionChart distribution={result.iterationDistribution} />
       </div>
 
       {/* Inefficient Sessions */}
@@ -396,4 +374,40 @@ function analyzeSessionEfficiency(data: IInsightsDay[]): IEfficiencyResult {
     insights,
     recommendations,
   }
+}
+
+function IterationDistributionChart({ distribution }: { distribution: Array<{ range: string; count: number; percentage: number }> }) {
+  const chartData = distribution.map(d => ({
+    range: d.range,
+    count: d.count,
+    percentage: d.percentage
+  }))
+
+  const getBarColor = (range: string) => {
+    if (range.includes('10+')) return '#f43f5e' // rose - inefficient
+    if (range.includes('7-9')) return '#f59e0b' // amber - concerning
+    if (range.includes('4-6')) return '#6366f1' // indigo - moderate
+    return '#10b981' // emerald - efficient
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={chartData} margin={{ top: 5, right: 20, left: 20, bottom: 5 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+        <XAxis dataKey="range" stroke="#94a3b8" fontSize={12} />
+        <YAxis stroke="#94a3b8" fontSize={12} label={{ value: 'Sessions', angle: -90, position: 'insideLeft', style: { fill: '#94a3b8' } }} />
+        <Tooltip
+          contentStyle={{ backgroundColor: '#1e293b', border: '1px solid #334155', borderRadius: '8px' }}
+          labelStyle={{ color: '#cbd5e1' }}
+          itemStyle={{ color: '#e2e8f0' }}
+          formatter={(value: any, name?: string) => [value, name === 'count' ? 'Sessions' : (name || '')]}
+        />
+        <Bar dataKey="count" radius={[4, 4, 0, 0]}>
+          {chartData.map((entry, index) => (
+            <Cell key={`cell-${index}`} fill={getBarColor(entry.range)} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  )
 }

--- a/web/src/pages/TimePatternsPage.tsx
+++ b/web/src/pages/TimePatternsPage.tsx
@@ -6,6 +6,7 @@ import { LoadingState, ErrorState, EmptyState } from '@/components/LoadingState'
 import { MetricCard } from '@/components/MetricCard'
 import { analyzeTimePatterns } from '@/lib/analyzers'
 import type { ITimePatternResult, ITimeSlotStats } from '@shared/analyzers/time-patterns'
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, Cell } from 'recharts'
 
 export function TimePatternsPage() {
   const { t } = useTranslation()
@@ -64,7 +65,8 @@ export function TimePatternsPage() {
       {/* Hourly Stats */}
       <div className="bg-slate-800 rounded-xl border border-slate-700 p-6">
         <h3 className="text-lg font-semibold text-white mb-4">Activity by Hour</h3>
-        <div className="grid grid-cols-6 gap-2">
+        <HourlyActivityChart hourlyStats={result.hourlyStats} />
+        <div className="grid grid-cols-6 gap-2 mt-6">
           {result.hourlyStats.map((stat) => (
             <TimeSlotCard key={stat.slot} stat={stat} />
           ))}
@@ -176,5 +178,42 @@ function PeriodCard({ periodStat }: { periodStat: ITimeSlotStats }) {
       <div className="text-2xl font-bold text-white mt-1">{periodStat.sessionCount}</div>
       <div className="text-xs text-slate-400">{periodStat.successRate}% success</div>
     </div>
+  )
+}
+
+function HourlyActivityChart({ hourlyStats }: { hourlyStats: ITimeSlotStats[] }) {
+  const chartData = hourlyStats.map(stat => ({
+    hour: stat.slot,
+    sessions: stat.sessionCount,
+    successRate: stat.successRate
+  }))
+
+  const getBarColor = (value: number, max: number) => {
+    const intensity = value / max
+    if (intensity > 0.7) return '#6366f1' // indigo
+    if (intensity > 0.4) return '#8b5cf6' // purple
+    return '#64748b' // slate
+  }
+
+  const maxSessions = Math.max(...chartData.map(d => d.sessions), 1)
+
+  return (
+    <ResponsiveContainer width="100%" height={200}>
+      <BarChart data={chartData} margin={{ top: 5, right: 10, left: 10, bottom: 5 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+        <XAxis dataKey="hour" stroke="#94a3b8" fontSize={11} angle={-45} textAnchor="end" height={60} />
+        <YAxis stroke="#94a3b8" fontSize={12} />
+        <Tooltip
+          contentStyle={{ backgroundColor: '#1e293b', border: '1px solid #334155', borderRadius: '8px' }}
+          labelStyle={{ color: '#cbd5e1' }}
+          itemStyle={{ color: '#e2e8f0' }}
+        />
+        <Bar dataKey="sessions" name="Sessions" radius={[4, 4, 0, 0]}>
+          {chartData.map((entry, index) => (
+            <Cell key={`cell-${index}`} fill={getBarColor(entry.sessions, maxSessions)} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
   )
 }


### PR DESCRIPTION
## Summary
5대 분석 기능을 Recharts 프로페셔널 차트로 시각화

## Changes

### ✨ 추가된 차트

**1. API Errors 페이지**
- ✅ LineChart - 에러 트렌드 (시계열)
- ✅ PieChart - 에러 유형 분포

**2. Category Success 페이지**
- ✅ BarChart - 카테고리별 성공률 비교
- ✅ RadarChart - 카테고리 성능 레이더

**3. Session Efficiency 페이지**
- ✅ BarChart - 반복 횟수 분포 (색상 코딩)

**4. Helpfulness 페이지**
- ✅ ScatterChart - 도움 정도 vs 성공률 상관관계

**5. Time Patterns 페이지**
- ✅ BarChart - 시간대별 활동 분포

### 🎨 개선사항
- 커스텀 div 차트 → Recharts 프로페셔널 차트로 교체
- 반응형 디자인 (ResponsiveContainer)
- 다크모드 스타일링 (#1e293b 배경)
- 인터랙티브 Tooltip
- 색상 코딩 (성공률 기반: emerald/amber/rose)

### 📊 차트 라이브러리
- **Recharts v3.7.0** 사용
- TreeShaking으로 필요한 컴포넌트만 import
- TypeScript 타입 안전성

### 🧪 테스트
- ✅ TypeScript 타입 체크 통과
- ✅ Vite 빌드 성공
- ✅ 번들 크기: 848.92 kB (gzip: 244.56 kB)

## Screenshots
(웹 대시보드 실행 후 스크린샷 추가 예정)

## 수락 기준
- [x] 5대 분석 페이지 모두 Recharts 차트 추가
- [x] 각 페이지 최소 1-2개 차트
- [x] 반응형 디자인
- [x] 다크모드 스타일링
- [x] 빌드 성공
- [x] TypeScript 에러 없음

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)